### PR TITLE
v1.0.5

### DIFF
--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -1,8 +1,10 @@
-Rails.application.config.middleware.use(
-  ExceptionNotification::Rack,
-  :email => {
-    :email_prefix => TaprootSetting.notifications.errors.email_prefix,
-    :sender_address => [TaprootSetting.notifications.errors.sender],
-    :exception_recipients => [TaprootSetting.notifications.errors.recipient]
-  }
-)
+if Rails.env.production?
+  Rails.application.config.middleware.use(
+    ExceptionNotification::Rack,
+    :email => {
+      :email_prefix => TaprootSetting.notifications.errors.email_prefix,
+      :sender_address => [TaprootSetting.notifications.errors.sender],
+      :exception_recipients => [TaprootSetting.notifications.errors.recipient]
+    }
+  )
+end

--- a/config/taproot.sample.yml
+++ b/config/taproot.sample.yml
@@ -44,6 +44,12 @@ development: &default
   remote:
     url:                ''                  # the url of your production app (e.g. cms.example.com)
     db_backup_file:     ''                  # reference to remote backup using ssh
+
+test:
+  <<: *default
+
+production:
+  <<: *default
   mailer:
     sendgrid:           false               # use sendgrid for sending emails?
     user_name:          ''                  # email username
@@ -57,9 +63,3 @@ development: &default
       email_prefix:     "[Taproot ERROR] "  # prefix to email subject
       sender:           ''                  # display name and email address for email
       recipient:        ''                  # who to send error notifications to
-
-test:
-  <<: *default
-
-production:
-  <<: *default


### PR DESCRIPTION
Starting server in development will throw error without having notifications block. But we don't need that, so ignore in dev.
