### PR TITLE
only search title and body

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -34,7 +34,7 @@ class Page < ActiveRecord::Base
 
   pg_search_scope(
     :search_content,
-    :against => [:title, :description, :body, :field_data],
+    :against => [:title, :body],
     :using => {
       :tsearch => {:dictionary => "english"}
     }


### PR DESCRIPTION
Only searching `title` and `body` for the time being. This simplifies it until we customize it further.
