### PR TITLE
v1.5.8

### DIFF
--- a/app/assets/javascripts/builder/routers/router.js.coffee
+++ b/app/assets/javascripts/builder/routers/router.js.coffee
@@ -15,7 +15,9 @@ class App.Routers.Router extends Backbone.Router
 
   routes:
     # Pages
+    'sites/:site_slug/pages?*filters': 'pages'
     'sites/:site_slug/pages/new': 'newPage'
+    'sites/:site_slug/pages/:page_slug?*filters': 'pages'
     'sites/:site_slug/pages/:page_slug/settings/:slug': 'editPage'
     'sites/:site_slug/pages/:page_slug/library': 'pageMedia'
     # Templates
@@ -30,6 +32,9 @@ class App.Routers.Router extends Backbone.Router
     'sites/:site_slug/library': 'library'
     # Forms
     'sites/:site_slug/forms/:form_slug/fields': 'formFields'
+
+  pages: (site_slug, page_slug = null) ->
+    new App.Views.PageSorter
 
   newPage: (site_slug) ->
     new App.Views.MarkdownEditor

--- a/app/assets/javascripts/builder/views/page_sorter.js.coffee
+++ b/app/assets/javascripts/builder/views/page_sorter.js.coffee
@@ -1,0 +1,27 @@
+class App.Views.PageSorter extends Backbone.View
+
+  el: 'body'
+
+  initialize: ->
+    if $('#page-content').data('sortable') == true
+      @initPageSort()
+
+  initPageSort: ->
+    sortable = $('.data-table').first().sortable
+      placeholder: 'sortable-placeholder'
+      toArray:
+        attribute: "data-id"
+      update: (e, ui) ->
+        ids = $(this).sortable('toArray', { attribute: 'data-id' })
+        for id, idx in ids
+          if id
+            form = $("article.page[data-id='#{id}']")
+              .find('form.page-position')
+              .first()
+            if parseInt(form.find('input.position').first().val()) != idx
+              form.find('input.position').first().val(idx)
+              $.ajax
+                type: "PATCH",
+                url: form.attr('action'),
+                data: form.serialize(),
+                dataType: 'json'

--- a/app/assets/stylesheets/builder/partials/data_tables.scss
+++ b/app/assets/stylesheets/builder/partials/data_tables.scss
@@ -132,7 +132,7 @@
 
       // ------------------------ Extra styles for sortable lists
 
-      &.form-field, &.resource-field, &.menu-item {
+      &.form-field, &.resource-field, &.menu-item, &.page.sortable {
         &:hover {
           cursor: move;
           cursor: -webkit-grab;
@@ -144,7 +144,7 @@
         > span.status a.unprotected {
           color: $color-grey;
         }
-        form.field-position, form.item-position {
+        form.field-position, form.item-position, form.page-position {
           display: none;
         }
       }

--- a/app/controllers/builder/pages_controller.rb
+++ b/app/controllers/builder/pages_controller.rb
@@ -50,7 +50,7 @@ class Builder::PagesController < BuilderController
         )
       end
     else
-      @pages = Kaminari.paginate_array(@pages).page(params[:page]).per(10)
+      @pages = Kaminari.paginate_array(@pages).page(params[:page]).per(15)
     end
   end
 
@@ -108,19 +108,27 @@ class Builder::PagesController < BuilderController
   end
 
   def update
-    process_files
-    slug = current_page.slug
-    if current_page.update(update_params)
-      # save_files
-      route = redirect_route.gsub(/#{slug}/, current_page.slug)
-      redirect_to(route,
-        :notice => t(
-          'notices.updated',
-          :item => controller_name.humanize.titleize
-        )
-      )
-    else
-      render('edit')
+    respond_to do |format|
+      format.html do
+        process_files
+        slug = current_page.slug
+        if current_page.update(update_params)
+          # save_files
+          route = redirect_route.gsub(/#{slug}/, current_page.slug)
+          redirect_to(route,
+            :notice => t(
+              'notices.updated',
+              :item => controller_name.humanize.titleize
+            )
+          )
+        else
+          render('edit')
+        end
+      end
+      format.json do
+        current_page.update!(update_params)
+        render :nothing => true
+      end
     end
   end
 

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -101,6 +101,18 @@ module PagesHelper
     end
   end
 
+  def sortable_pages?
+    pages = (action_name == 'index') ? @pages : current_page_children
+    template_ids = pages.collect(&:template_id).uniq.map(&:to_i)
+    templates = site_templates.select { |t| template_ids.include?(t.id) }
+    order_methods = templates.collect(&:order_method).uniq.reject(&:blank?)
+    if order_methods.size <= 1 && order_methods.first == 'position'
+      true
+    else
+      false
+    end
+  end
+
   def eligible_parents(page)
     @eligible_parents ||= begin
       pages = []

--- a/app/views/builder/pages/_form.html.erb
+++ b/app/views/builder/pages/_form.html.erb
@@ -32,10 +32,19 @@
         <% end %>
       <% end %>
 
-      <% if ['title','slug','position','description','show_in_nav'].include?(field.slug) %>
+      <% if ['title','slug','description','show_in_nav'].include?(field.slug) %>
         <%= f.input(
           field.slug.to_sym,
           :label => field.label,
+          :input_html => {
+            :value => current_page.send(field.slug) || field.default_value
+          }
+        ) unless field.hidden? %>
+      <% elsif field.slug == 'position' %>
+        <%= f.input(
+          field.slug.to_sym,
+          :label => field.label,
+          :as => :string,
           :input_html => {
             :value => current_page.send(field.slug) || field.default_value
           }

--- a/app/views/builder/pages/_page.html.erb
+++ b/app/views/builder/pages/_page.html.erb
@@ -1,4 +1,4 @@
-<article class="page">
+<article class="page <%= 'sortable' if sortable_pages? %>" data-id="<%= page.id %>">
   <%= content_tag(:span, page_quick_status(page), :class => 'status') %>
   <div class="data">
     <div class="top">
@@ -13,6 +13,12 @@
         :class => 'path'
       ) if page.template.has_show_view? %>
     </div>
+    <%= simple_form_for(
+      [:builder, current_site, page],
+      :html => { :class => 'page-position' }
+    ) do |f| %>
+      <%= f.input :position, :input_html => { :class => 'position' } %>
+    <% end if sortable_pages? %>
     <div class="bottom">
       <%= page_last_edited(page) %>
       <%= link_to(

--- a/app/views/builder/pages/index.html.erb
+++ b/app/views/builder/pages/index.html.erb
@@ -3,7 +3,8 @@
   <%= page_search_field %>
 <% end %>
 
-<section id="page-content" class="data-container">
+<section id="page-content" class="data-container"
+        data-sortable="<%= sortable_pages? %>">
   <% if @pages.size > 0 %>
     <%= render :partial => 'filters', :locals => { :pages => site_root_pages } %>
     <%= data_table(@pages, 'page') %>

--- a/app/views/builder/pages/show.html.erb
+++ b/app/views/builder/pages/show.html.erb
@@ -7,7 +7,8 @@
   <%= render :partial => 'tabs' %>
 <% end %>
 
-<section id="page-content" class="full-width pages data-container">
+<section id="page-content" class="full-width pages data-container"
+         data-sortable="<%= sortable_pages? %>">
   <%= render :partial => 'filters', :locals => {
     :pages => current_page_children } %>
   <% if current_page_children_filtered_paginated.size > 0 %>


### PR DESCRIPTION
add a drag-and-drop feature for reordering pages if all the eligible templates use `position` for `order_method` or have a blank `order_method`
