### PR TITLE
v1.6.5

### DIFF
--- a/app/controllers/viewer/pages_controller.rb
+++ b/app/controllers/viewer/pages_controller.rb
@@ -4,8 +4,10 @@ class Viewer::PagesController < ViewerController
   before_filter :set_home_page, :only => [:home]
   before_filter :set_current_page, :only => [:show]
 
-  caches_action :home, :cache_path => :show_cache_path.to_proc
-  caches_action :show, :cache_path => :show_cache_path.to_proc
+  caches_action :home, :cache_path => :show_cache_path.to_proc,
+                :if => Proc.new { controller_name != 'previewer' }
+  caches_action :show, :cache_path => :show_cache_path.to_proc,
+                :if => Proc.new { controller_name != 'previewer' }
 
   unless Rails.env.development?
     rescue_from ActionController::RoutingError do |e|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
   # config.cache_store = :mem_cache_store
   # config.cache_store = :redis_store, 'redis://localhost:6379/0/cache', { expires_in: 90.minutes }
 


### PR DESCRIPTION
Don't cache pages in previewer mode. This was causing problems with links working in production.

Note that this does not support allowing a site to be accessed on a relative and non-relative root, but that should be okay for now.
